### PR TITLE
feat: Add Elixir language support

### DIFF
--- a/cli/grammars/elixir.tmLanguage.json
+++ b/cli/grammars/elixir.tmLanguage.json
@@ -1,0 +1,1022 @@
+{
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/elixir-editors/elixir-tmbundle/blob/master/Syntaxes/Elixir.tmLanguage",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "version": "https://github.com/elixir-editors/elixir-tmbundle/commit/43c8cd957d5ac6e1abbd8730fc7a08c81a6e76c9",
+  "name": "Elixir",
+  "scopeName": "source.elixir",
+  "comment": "Textmate bundle for Elixir Programming Language.",
+  "fileTypes": [
+    "ex",
+    "exs"
+  ],
+  "firstLineMatch": "^#!/.*\\belixir",
+  "foldingStartMarker": "(after|else|catch|rescue|\\-\\>|\\{|\\[|do)\\s*$",
+  "foldingStopMarker": "^\\s*((\\}|\\]|after|else|catch|rescue)\\s*$|end\\b)",
+  "keyEquivalent": "^~E",
+  "patterns": [
+    {
+      "begin": "\\b(fn)\\b(?!.*->)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.elixir"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#core_syntax"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "entity.name.type.class.elixir"
+        },
+        "2": {
+          "name": "punctuation.separator.method.elixir"
+        },
+        "3": {
+          "name": "entity.name.function.elixir"
+        }
+      },
+      "match": "([A-Z]\\w+)\\s*(\\.)\\s*([a-z_]\\w*[!?]?)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "constant.other.symbol.elixir"
+        },
+        "2": {
+          "name": "punctuation.separator.method.elixir"
+        },
+        "3": {
+          "name": "entity.name.function.elixir"
+        }
+      },
+      "match": "(\\:\\w+)\\s*(\\.)\\s*([_]?\\w*[!?]?)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.other.elixir"
+        },
+        "2": {
+          "name": "entity.name.function.elixir"
+        }
+      },
+      "match": "(\\|\\>)\\s*([a-z_]\\w*[!?]?)"
+    },
+    {
+      "match": "\\b[a-z_]\\w*[!?]?(?=\\s*\\.?\\s*\\()",
+      "name": "entity.name.function.elixir"
+    },
+    {
+      "begin": "\\b(fn)\\b(?=.*->)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.elixir"
+        }
+      },
+      "end": "(?>(->)|(when)|(\\)))",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.operator.other.elixir"
+        },
+        "2": {
+          "name": "keyword.control.elixir"
+        },
+        "3": {
+          "name": "punctuation.section.function.elixir"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#core_syntax"
+        }
+      ]
+    },
+    {
+      "include": "#core_syntax"
+    },
+    {
+      "begin": "^(?=.*->)((?![^\"']*(\"|')[^\"']*->)|(?=.*->[^\"']*(\"|')[^\"']*->))((?!.*\\([^\\)]*->)|(?=[^\\(\\)]*->)|(?=\\s*\\(.*\\).*->))((?!.*\\b(fn)\\b)|(?=.*->.*\\bfn\\b))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.elixir"
+        }
+      },
+      "end": "(?>(->)|(when)|(\\)))",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.operator.other.elixir"
+        },
+        "2": {
+          "name": "keyword.control.elixir"
+        },
+        "3": {
+          "name": "punctuation.section.function.elixir"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#core_syntax"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "core_syntax": {
+      "patterns": [
+        {
+          "begin": "^\\s*(defmodule)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.module.elixir"
+            }
+          },
+          "end": "\\b(do)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.module.elixir"
+            }
+          },
+          "name": "meta.module.elixir",
+          "patterns": [
+            {
+              "match": "\\b[A-Z]\\w*(?=\\.)",
+              "name": "entity.other.inherited-class.elixir"
+            },
+            {
+              "match": "\\b[A-Z]\\w*\\b",
+              "name": "entity.name.type.class.elixir"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(defprotocol)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.protocol.elixir"
+            }
+          },
+          "end": "\\b(do)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.protocol.elixir"
+            }
+          },
+          "name": "meta.protocol_declaration.elixir",
+          "patterns": [
+            {
+              "match": "\\b[A-Z]\\w*\\b",
+              "name": "entity.name.type.protocol.elixir"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(defimpl)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.protocol.elixir"
+            }
+          },
+          "end": "\\b(do)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.protocol.elixir"
+            }
+          },
+          "name": "meta.protocol_implementation.elixir",
+          "patterns": [
+            {
+              "match": "\\b[A-Z]\\w*\\b",
+              "name": "entity.name.type.protocol.elixir"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(def|defmacro|defdelegate|defguard)\\s+((?>[a-zA-Z_]\\w*(?>\\.|::))?(?>[a-zA-Z_]\\w*(?>[?!]|=(?!>))?|===?|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[\\]=?))((\\()|\\s*)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.module.elixir"
+            },
+            "2": {
+              "name": "entity.name.function.public.elixir"
+            },
+            "4": {
+              "name": "punctuation.section.function.elixir"
+            }
+          },
+          "end": "(\\bdo:)|(\\bdo\\b)|(?=\\s+(def|defn|defmacro|defdelegate|defguard)\\b)",
+          "endCaptures": {
+            "1": {
+              "name": "constant.other.keywords.elixir"
+            },
+            "2": {
+              "name": "keyword.control.module.elixir"
+            }
+          },
+          "name": "meta.function.public.elixir",
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "begin": "\\s(\\\\\\\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.operator.other.elixir"
+                }
+              },
+              "end": ",|\\)|$",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "match": "\\b(is_atom|is_binary|is_bitstring|is_boolean|is_float|is_function|is_integer|is_list|is_map|is_nil|is_number|is_pid|is_port|is_record|is_reference|is_tuple|is_exception|abs|bit_size|byte_size|div|elem|hd|length|map_size|node|rem|round|tl|trunc|tuple_size)\\b",
+              "name": "keyword.control.elixir"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(defp|defnp|defmacrop|defguardp)\\s+((?>[a-zA-Z_]\\w*(?>\\.|::))?(?>[a-zA-Z_]\\w*(?>[?!]|=(?!>))?|===?|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[\\]=?))((\\()|\\s*)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.module.elixir"
+            },
+            "2": {
+              "name": "entity.name.function.private.elixir"
+            },
+            "4": {
+              "name": "punctuation.section.function.elixir"
+            }
+          },
+          "end": "(\\bdo:)|(\\bdo\\b)|(?=\\s+(defp|defmacrop|defguardp)\\b)",
+          "endCaptures": {
+            "1": {
+              "name": "constant.other.keywords.elixir"
+            },
+            "2": {
+              "name": "keyword.control.module.elixir"
+            }
+          },
+          "name": "meta.function.private.elixir",
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "begin": "\\s(\\\\\\\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.operator.other.elixir"
+                }
+              },
+              "end": ",|\\)|$",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "match": "\\b(is_atom|is_binary|is_bitstring|is_boolean|is_float|is_function|is_integer|is_list|is_map|is_nil|is_number|is_pid|is_port|is_record|is_reference|is_tuple|is_exception|abs|bit_size|byte_size|div|elem|hd|length|map_size|node|rem|round|tl|trunc|tuple_size)\\b",
+              "name": "keyword.control.elixir"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*~L\"\"\"",
+          "comment": "Leex Sigil",
+          "end": "\\s*\"\"\"",
+          "name": "sigil.leex",
+          "patterns": [
+            {
+              "include": "text.elixir"
+            },
+            {
+              "include": "text.html.basic"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*~H\"\"\"",
+          "comment": "HEEx Sigil",
+          "end": "\\s*\"\"\"",
+          "name": "sigil.heex",
+          "patterns": [
+            {
+              "include": "text.elixir"
+            },
+            {
+              "include": "text.html.basic"
+            }
+          ]
+        },
+        {
+          "begin": "@(module|type)?doc (~[a-z])?\"\"\"",
+          "comment": "@doc with heredocs is treated as documentation",
+          "end": "\\s*\"\"\"",
+          "name": "comment.block.documentation.heredoc",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "@(module|type)?doc ~[A-Z]\"\"\"",
+          "comment": "@doc with heredocs is treated as documentation",
+          "end": "\\s*\"\"\"",
+          "name": "comment.block.documentation.heredoc"
+        },
+        {
+          "begin": "@(module|type)?doc (~[a-z])?'''",
+          "comment": "@doc with heredocs is treated as documentation",
+          "end": "\\s*'''",
+          "name": "comment.block.documentation.heredoc",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "@(module|type)?doc ~[A-Z]'''",
+          "comment": "@doc with heredocs is treated as documentation",
+          "end": "\\s*'''",
+          "name": "comment.block.documentation.heredoc"
+        },
+        {
+          "comment": "@doc false is treated as documentation",
+          "match": "@(module|type)?doc false",
+          "name": "comment.block.documentation.false"
+        },
+        {
+          "begin": "@(module|type)?doc \"",
+          "comment": "@doc with string is treated as documentation",
+          "end": "\"",
+          "name": "comment.block.documentation.string",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defnp?|defmacrop?|defguardp?|defdelegate|defexception|defoverridable|exit|after|rescue|catch|else|raise|reraise|throw|import|require|alias|use|quote|unquote|super|with)\\b(?![?!:])",
+          "name": "keyword.control.elixir"
+        },
+        {
+          "comment": " as above, just doesn't need a 'end' and does a logic operation",
+          "match": "(?<!\\.)\\b(and|not|or|when|xor|in)\\b",
+          "name": "keyword.operator.elixir"
+        },
+        {
+          "match": "\\b[A-Z]\\w*\\b",
+          "name": "entity.name.type.class.elixir"
+        },
+        {
+          "match": "\\b(nil|true|false)\\b(?![?!])",
+          "name": "constant.language.elixir"
+        },
+        {
+          "match": "\\b(__(CALLER|ENV|MODULE|DIR|STACKTRACE)__)\\b(?![?!])",
+          "name": "variable.language.elixir"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.elixir"
+            }
+          },
+          "match": "(@)[a-zA-Z_]\\w*",
+          "name": "variable.other.readwrite.module.elixir"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.elixir"
+            }
+          },
+          "match": "(&)\\d+",
+          "name": "variable.other.anonymous.elixir"
+        },
+        {
+          "match": "&(?![&])",
+          "name": "variable.other.anonymous.elixir"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.elixir"
+            }
+          },
+          "match": "\\^[a-z_]\\w*",
+          "name": "variable.other.capture.elixir"
+        },
+        {
+          "match": "\\b0x[0-9A-Fa-f](?>_?[0-9A-Fa-f])*\\b",
+          "name": "constant.numeric.hex.elixir"
+        },
+        {
+          "match": "\\b\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)+)([eE][-+]?\\d(?>_?\\d)*)?\\b",
+          "name": "constant.numeric.float.elixir"
+        },
+        {
+          "match": "\\b\\d(?>_?\\d)*\\b",
+          "name": "constant.numeric.integer.elixir"
+        },
+        {
+          "match": "\\b0b[01](?>_?[01])*\\b",
+          "name": "constant.numeric.binary.elixir"
+        },
+        {
+          "match": "\\b0o[0-7](?>_?[0-7])*\\b",
+          "name": "constant.numeric.octal.elixir"
+        },
+        {
+          "begin": ":'",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.constant.elixir"
+            }
+          },
+          "end": "'",
+          "name": "constant.other.symbol.single-quoted.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": ":\"",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.constant.elixir"
+            }
+          },
+          "end": "\"",
+          "name": "constant.other.symbol.double-quoted.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "(?>''')",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "Single-quoted heredocs",
+          "end": "^\\s*'''",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.single.heredoc.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "single quoted string (allows for interpolation)",
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.single.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "(?>\"\"\")",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "Double-quoted heredocs",
+          "end": "^\\s*\"\"\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.double.heredoc.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "double quoted string (allows for interpolation)",
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.double.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[a-z](?>\"\"\")",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "Double-quoted heredocs sigils",
+          "end": "^\\s*\"\"\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.heredoc.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[a-z]\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (allow for interpolation)",
+          "end": "\\}[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[a-z]\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (allow for interpolation)",
+          "end": "\\][a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[a-z]\\<",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (allow for interpolation)",
+          "end": "\\>[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[a-z]\\(",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (allow for interpolation)",
+          "end": "\\)[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[a-z]([^\\w])",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (allow for interpolation)",
+          "end": "\\1[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.elixir",
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "~[A-Z](?>\"\"\")",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "Double-quoted heredocs sigils",
+          "end": "^\\s*\"\"\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.heredoc.literal.elixir"
+        },
+        {
+          "begin": "~[A-Z]\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (without interpolation)",
+          "end": "\\}[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.literal.elixir"
+        },
+        {
+          "begin": "~[A-Z]\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (without interpolation)",
+          "end": "\\][a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.literal.elixir"
+        },
+        {
+          "begin": "~[A-Z]\\<",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (without interpolation)",
+          "end": "\\>[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.literal.elixir"
+        },
+        {
+          "begin": "~[A-Z]\\(",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (without interpolation)",
+          "end": "\\)[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.literal.elixir"
+        },
+        {
+          "begin": "~[A-Z]([^\\w])",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.elixir"
+            }
+          },
+          "comment": "sigil (without interpolation)",
+          "end": "\\1[a-z]*",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.elixir"
+            }
+          },
+          "name": "string.quoted.other.sigil.literal.elixir"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.constant.elixir"
+            }
+          },
+          "comment": "symbols",
+          "match": "(?<!:)(:)(?>[a-zA-Z_][\\w@]*(?>[?!]|=(?![>=]))?|\\<\\>|===?|!==?|<<>>|<<<|>>>|~~~|::|<\\-|\\|>|=>|=~|=|/|\\\\\\\\|\\*\\*?|\\.\\.?\\.?|\\.\\.//|>=?|<=?|&&?&?|\\+\\+?|\\-\\-?|\\|\\|?\\|?|\\!|@|\\%?\\{\\}|%|\\[\\]|\\^(\\^\\^)?)",
+          "name": "constant.other.symbol.elixir"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.constant.elixir"
+            }
+          },
+          "comment": "symbols",
+          "match": "(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)",
+          "name": "constant.other.keywords.elixir"
+        },
+        {
+          "begin": "(^[ \\t]+)?(?=##)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.elixir"
+            }
+          },
+          "end": "(?!#)",
+          "patterns": [
+            {
+              "begin": "##",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.elixir"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.section.elixir"
+            }
+          ]
+        },
+        {
+          "begin": "(^[ \\t]+)?(?=#)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.elixir"
+            }
+          },
+          "end": "(?!#)",
+          "patterns": [
+            {
+              "begin": "#",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.elixir"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.number-sign.elixir"
+            }
+          ]
+        },
+        {
+          "match": "\\b_([^_][\\w]+[?!]?)",
+          "name": "comment.unused.elixir"
+        },
+        {
+          "match": "\\b_\\b",
+          "name": "comment.wildcard.elixir"
+        },
+        {
+          "comment": "\n\t\t\tmatches questionmark-letters.\n\n\t\t\texamples (1st alternation = hex):\n\t\t\t?\\x1     ?\\x61\n\n\t\t\texamples (2rd alternation = escaped):\n\t\t\t?\\n      ?\\b\n\n\t\t\texamples (3rd alternation = normal):\n\t\t\t?a       ?A       ?0\n\t\t\t?*       ?\"       ?(\n\t\t\t?.       ?#\n\n\t\t\tthe negative lookbehind prevents against matching\n\t\t\tp(42.tainted?)\n\t\t\t",
+          "match": "(?<!\\w)\\?(\\\\(x[0-9A-Fa-f]{1,2}(?![0-9A-Fa-f])\\b|[^xMC])|[^\\s\\\\])",
+          "name": "constant.numeric.elixir"
+        },
+        {
+          "match": "\\+\\+|\\-\\-|<\\|>",
+          "name": "keyword.operator.concatenation.elixir"
+        },
+        {
+          "match": "\\|\\>|<~>|<>|<<<|>>>|~>>|<<~|~>|<~|<\\|>",
+          "name": "keyword.operator.sigils_1.elixir"
+        },
+        {
+          "match": "&&&|&&",
+          "name": "keyword.operator.sigils_2.elixir"
+        },
+        {
+          "match": "<\\-|\\\\\\\\",
+          "name": "keyword.operator.sigils_3.elixir"
+        },
+        {
+          "match": "===?|!==?|<=?|>=?",
+          "name": "keyword.operator.comparison.elixir"
+        },
+        {
+          "match": "(\\|\\|\\||&&&|\\^\\^\\^|<<<|>>>|~~~)",
+          "name": "keyword.operator.bitwise.elixir"
+        },
+        {
+          "match": "(?<=[ \\t])!+|\\bnot\\b|&&|\\band\\b|\\|\\||\\bor\\b|\\bxor\\b",
+          "name": "keyword.operator.logical.elixir"
+        },
+        {
+          "match": "(\\*|\\+|\\-|/)",
+          "name": "keyword.operator.arithmetic.elixir"
+        },
+        {
+          "match": "\\||\\+\\+|\\-\\-|\\*\\*|\\\\\\\\|\\<\\-|\\<\\>|\\<\\<|\\>\\>|\\:\\:|\\.\\.|//|\\|>|~|=>|&",
+          "name": "keyword.operator.other.elixir"
+        },
+        {
+          "match": "=",
+          "name": "keyword.operator.assignment.elixir"
+        },
+        {
+          "match": ":",
+          "name": "punctuation.separator.other.elixir"
+        },
+        {
+          "match": "\\;",
+          "name": "punctuation.separator.statement.elixir"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.object.elixir"
+        },
+        {
+          "match": "\\.",
+          "name": "punctuation.separator.method.elixir"
+        },
+        {
+          "match": "\\{|\\}",
+          "name": "punctuation.section.scope.elixir"
+        },
+        {
+          "match": "\\[|\\]",
+          "name": "punctuation.section.array.elixir"
+        },
+        {
+          "match": "\\(|\\)",
+          "name": "punctuation.section.function.elixir"
+        }
+      ]
+    },
+    "escaped_char": {
+      "match": "\\\\(x[\\da-fA-F]{1,2}|.)",
+      "name": "constant.character.escaped.elixir"
+    },
+    "interpolated_elixir": {
+      "begin": "#\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.begin.elixir"
+        }
+      },
+      "contentName": "source.elixir",
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.end.elixir"
+        }
+      },
+      "name": "meta.embedded.line.elixir",
+      "patterns": [
+        {
+          "include": "#nest_curly_and_self"
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    "nest_curly_and_self": {
+      "patterns": [
+        {
+          "begin": "\\{",
+          "captures": {
+            "0": {
+              "name": "punctuation.section.scope.elixir"
+            }
+          },
+          "end": "\\}",
+          "patterns": [
+            {
+              "include": "#nest_curly_and_self"
+            }
+          ]
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    }
+  },
+  "uuid": "D00C06B9-71B2-4FEB-A0E3-37237F579456"
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -22,7 +22,8 @@
       },
       "bin": {
         "vscodethemes": "build/cli.js",
-        "vscodethemes-image": "build/cli-image.js"
+        "vscodethemes-images": "build/cli-images.js",
+        "vscodethemes-info": "build/cli-info.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.7.0",

--- a/cli/src/lib/language-templates.ts
+++ b/cli/src/lib/language-templates.ts
@@ -153,5 +153,20 @@ export const ruby = `class Calculator
   def calculate
     ops.each { |op| puts op.call }
   end
+`;
+
+export const elixir = `defmodule TextAnalyzer do
+  @default_text "Hey there!"
+
+  def count_words(text \\\\ @default_text) do
+    text
+    |> String.split()
+    |> length()
+  end
 end
+
+# Print word count
+"Hello world!"
+|> TextAnalyzer.count_words()
+|> IO.puts()
 `;

--- a/cli/src/lib/languages.ts
+++ b/cli/src/lib/languages.ts
@@ -90,6 +90,15 @@ const defaultLanguages = [
     template: templates.rust,
     tabName: "main.rs",
   },
+
+  {
+    name: "Elixir",
+    extName: "ex",
+    scopeName: "source.elixir",
+    grammar: "elixir.tmLanguage.json",
+    template: templates.elixir,
+    tabName: "main.ex",
+  },
 ] as const;
 
 export default defaultLanguages;


### PR DESCRIPTION
## Description
Hi @jschr  👋
I'd like to add support for the Elixir language. This PR includes the necessary backend changes to enable Elixir syntax highlighting and display.

Resolves https://github.com/vscodethemes/web/issues/293

## What’s included:
1. **Grammar File**
Added `cli/grammars/elixir.tmLanguage.json`, generated from this [`Elixir.tmLanguage`](https://github.com/elixir-editors/elixir-tmbundle/blob/master/Syntaxes/Elixir.tmLanguage) file.
Converted using [plist-to-json](https://www.npmjs.com/package/plist-to-json).

2. **Code Snippet**
Included an Elixir code that meets the formatting and content guidelines (14 lines, valid syntax, includes a comment).

3. **Language Registration**
Added "Elixir" to the list of supported languages.

## Generated Image
![night-owl-color-theme-ex](https://github.com/user-attachments/assets/242f11d9-c308-4011-9b8e-bb9b1b28567a)
